### PR TITLE
Remove folders without unit tests for ES

### DIFF
--- a/config/implementation/jsc-debug.json
+++ b/config/implementation/jsc-debug.json
@@ -13,6 +13,10 @@
   "sourceBranch": "master",
   "sourceExcludes": {
     "foundInFile": [ "$vm" ],
-    "paths": [ "mozilla/**" , "ChakraCore/**",  "ChangeLog", "*.yaml" , "microbenchmarks/**" , "test262/**"]
+    "paths":[
+      "mozilla/**" , "ChakraCore/**",  "ChangeLog", "*.yaml" , "microbenchmarks/**", "test262/**",
+      "executableAllocationFuzz/**", "heapProfiler/**", "perf/**", "regexp/**",
+      "slowMicrobenchmarks/**", "typeProfiler/**"
+    ]
   }
 }

--- a/config/implementation/jsc.json
+++ b/config/implementation/jsc.json
@@ -13,6 +13,10 @@
   "sourceBranch": "master",
   "sourceExcludes": {
     "foundInFile": ["$vm" ],
-    "paths": [ "mozilla/**" , "ChakraCore/**",  "ChangeLog", "*.yaml" , "microbenchmarks/**", "test262/**" ]
+    "paths":[
+      "mozilla/**" , "ChakraCore/**",  "ChangeLog", "*.yaml" , "microbenchmarks/**", "test262/**",
+      "executableAllocationFuzz/**", "heapProfiler/**", "perf/**", "regexp/**",
+      "slowMicrobenchmarks/**", "typeProfiler/**"
+    ]
   }
 }


### PR DESCRIPTION
I observed each file in each of these folders and they don't contain any test matching for specific parts of ECMAScript, without a specific place for Test262.

This should meet a follow up PR on Test262 removing the same files.